### PR TITLE
fix cellClick Event not working

### DIFF
--- a/src/components/row.template.ts
+++ b/src/components/row.template.ts
@@ -18,7 +18,7 @@ export const ROW_TEMPLATE = `
         <input type="checkbox" [(ngModel)]="selected"/>
     </td>
     <td *ngFor="let column of dataTable.columns" [hide]="!column.visible" [ngClass]="column.styleClassObject" class="data-column"
-        [style.background-color]="column.getCellColor(_this, index)">
+        [style.background-color]="column.getCellColor(_this, index)" (click)="dataTable.cellClicked(column, _this, $event)">
         <div *ngIf="!column.cellTemplate" [textContent]="item[column.property]"></div>
         <div *ngIf="column.cellTemplate" [ngTemplateOutlet]="column.cellTemplate" [ngOutletContext]="{column: column, row: _this, item: item}"></div>
     </td>

--- a/src/components/table.component.ts
+++ b/src/components/table.component.ts
@@ -230,7 +230,7 @@ export class DataTable implements DataTableParams, OnInit {
         }
     }
 
-    private cellClicked(column: DataTableColumn, row: DataTableRow, event: MouseEvent) {
+    public cellClicked(column: DataTableColumn, row: DataTableRow, event: MouseEvent) {
         this.cellClick.emit({ row, column, event });
     }
 


### PR DESCRIPTION
Fixes #3
Adding ability to optionally detect clicks on each cell instead of using entire row